### PR TITLE
Fix Magic Bullets

### DIFF
--- a/scripts/functions.gsc
+++ b/scripts/functions.gsc
@@ -424,26 +424,41 @@ quake(player)
 {
     earthquake( 0.6, 5, player.origin, 1000000 );
 }
-//magic bullets, need to fix the popup error , works for time being 
-magicbullets(bullettype)
+magicbullets()//Fixed and rewritten for BO4 by TheUnknownCod3r / MrFawkes1337
 {
-    if(!isDefined(self.gamevars["magicbullet"]) || self.gamevars["magicbullet"] == false)
+    self.magicBullet = isDefined(self.magicBullet) ? undefined : true;
+    if(isDefined(self.magicBullet))
     {
-        self.gamevars["magicbullet"] = true;
-        self iprintlnBold("Magic Bullets ^2Enabled");
-        while(self.gamevars["magicbullet"])
+        self.bulletEffectType = "launcher_standard_t8_upgraded";
+        self S("Magic Bullets Enabled, Effect: Rocket Launcher");
+        while(isDefined(self.magicBullet))
         {
-            self waittill( "weapon_fired" );
-            if(self.gamevars["magicbullet"] == false)
-                continue;
-            MagicBullet( GetWeapon( bullettype ), self GetEye(), BulletTrace(self GetEye(), self GetEye() + AnglesToForward(self GetPlayerAngles()) * 100000, false, self)["position"], self);
-            wait .025;
+            self waittill(#"weapon_fired");
+            MagicBullet(getWeapon(self.bulletEffectType), self getPlayerCameraPos(), BulletTrace(self getPlayerCameraPos(), self getPlayerCameraPos() + anglesToForward(self getPlayerAngles())  * 100000, false, self)["position"], self);
+            wait .25;
+        }
+    }
+    else 
+    {
+        self S("Bullet Effects ^1Disabled");
+        self.bulletEffectType=undefined;
+    }
+}
+
+changeBulletType(val)
+{
+    if(isDefined(self.bulletEffectType))
+    {
+        switch(val)
+        {
+            case 0: self.bulletEffectType="minigun"; self S("Bullet Effect Set To: Minigun"); break;
+            case 1: self.bulletEffectType = "special_ballisticknife_t8_dw_upgraded"; self S("Bullet Effect Set To: Ballistic Knife"); break;
+            case 2: self.bulletEffectType = "launcher_standard_t8_upgraded"; self S("Bullet Effect Set To: Rocket Launcher"); break;
         }
     }
     else
     {
-        self.gamevars["magicbullet"] = false;
-        self iprintlnBold("Magic Bullets ^1Disabled");
+        self S("Custom Bullet Effects are not Enabled");
     }
 }
 zignore(player)

--- a/scripts/functions.gsc
+++ b/scripts/functions.gsc
@@ -430,7 +430,7 @@ magicbullets()//Fixed and rewritten for BO4 by TheUnknownCod3r / MrFawkes1337
     if(isDefined(self.magicBullet))
     {
         self.bulletEffectType = "launcher_standard_t8_upgraded";
-        self S("Magic Bullets Enabled, Effect: Rocket Launcher");
+        self iPrintLnBold("Magic Bullets ^2Enabled");
         while(isDefined(self.magicBullet))
         {
             self waittill(#"weapon_fired");
@@ -440,25 +440,26 @@ magicbullets()//Fixed and rewritten for BO4 by TheUnknownCod3r / MrFawkes1337
     }
     else 
     {
-        self S("Bullet Effects ^1Disabled");
+        self iPrintLnBold("Bullet Effects ^1Disabled");
         self.bulletEffectType=undefined;
     }
 }
 
-changeBulletType(val)
+changeBulletEffect(val)
 {
     if(isDefined(self.bulletEffectType))
     {
         switch(val)
         {
-            case 0: self.bulletEffectType="minigun"; self S("Bullet Effect Set To: Minigun"); break;
-            case 1: self.bulletEffectType = "special_ballisticknife_t8_dw_upgraded"; self S("Bullet Effect Set To: Ballistic Knife"); break;
-            case 2: self.bulletEffectType = "launcher_standard_t8_upgraded"; self S("Bullet Effect Set To: Rocket Launcher"); break;
+            case 0: self.bulletEffectType="minigun"; self iPrintLnBold("Bullet Effect Set To: ^2Minigun"); break;
+            case 1: self.bulletEffectType = "special_ballisticknife_t8_dw_upgraded"; self iPrintLnBold("Bullet Effect Set To: ^2Ballistic Knife"); break;
+            case 2: self.bulletEffectType = "launcher_standard_t8_upgraded"; self iPrintLnBold("Bullet Effect Set To: ^2Rocket Launcher"); break;
+	    case 3: self.bulletEffectType = "ray_gun_upgraded"; self iPrintLnBold("Bullet Effect Set To: ^2Ray Gun"); break;
         }
     }
     else
     {
-        self S("Custom Bullet Effects are not Enabled");
+        self iPrintLnBold("Custom Bullet Effects are not Enabled");
     }
 }
 zignore(player)

--- a/scripts/menu.gsc
+++ b/scripts/menu.gsc
@@ -327,12 +327,11 @@ MenuOptionsPlayer(menu, player)
         break;
         case "Bullets Menu":
         self addMenu(menu, "Bullets Menu");
-            self addOpt("= Turn OFF The Current One =");
-            self addOpt("= Before Applying Another =");
-            self addOpt("Porters x2 Ray Gun", &magicbullets, "ray_gun_upgraded");
-            self addOpt("Hellion Salvo", &magicbullets, "launcher_standard_t8_upgraded");
-            self addOpt("Minigun", &magicbullets, "minigun");
-            self addOpt("Ballistic Knife", &magicbullets, "special_ballisticknife_t8_dw_upgraded");
+            self addOptBool(self.magicBullet, "Toggle Magic Bullets", &magicbullets);
+            self addOpt("Porters x2 Ray Gun", &changeBulletEffect, 3);
+            self addOpt("Hellion Salvo", &changeBulletEffect, 2);
+            self addOpt("Minigun", &changeBulletEffect, 0);
+            self addOpt("Ballistic Knife", &changeBulletEffect, 1);
         break;
         case "Powerups Menu":
             self addMenu(menu, "Powerups Menu");


### PR DESCRIPTION
The way MagicBullets is called on BO4 seems to differ in regards to BO3 and previous releases. In previous games, using GetEye() would resolve correctly, however in BO4 this seems to be the cause in the function of the UI Popup. The raw scripts use a different method when calling MagicBullets for other Wonder Weapons, and I just replaced GetEye with GetPlayerCameraPos(), and cleaned up the script a bit to make sure it works, and looks clean. It tests fine in game, However I don't use the Ray Gun effect, so I don't know if this works. 